### PR TITLE
Participant Env

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM registry.access.redhat.com/ubi8:latest
+
+# Install dependencies
+RUN yum install -y python3-pip git && \
+    /usr/bin/pip3 install ansible github3.py openshift && \
+    curl -o /tmp/openshift-client-linux.tar.gz https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz && \
+    tar -xzvf /tmp/openshift-client-linux.tar.gz -C /usr/local/bin/ && \
+    chmod +x /usr/local/bin/oc && \
+    rm /usr/local/bin/README.md && \
+    rm /usr/local/bin/kubectl && \
+    rm /tmp/openshift-client-linux.tar.gz && \
+    yum clean all -y


### PR DESCRIPTION
This PR adds a `Dockerfile` to the root of the repo that contains the `oc` binary as well as `ansible==2.9` and the requisite Python modules for our playbooks to run (`github3.py` and `openshift`).

The resulting container image can be used locally by participants to have a sane default environment, or can be consumed as part of a Code Ready Workspace to accomplish the same.