### PR TITLE
set temp dirs to use for containerized execution

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,3 @@
+[defaults]
+remote_tmp = /tmp
+local_tmp = /tmp


### PR DESCRIPTION
When running inside of our container on k8s/OpenShift, a user with a random UID is used and doesn't have permission to write to much. This `ansible.cfg` tells ansible to use `/tmp` for all required temp dirs.

Tested in Code Ready Workspace, a primary use-case for our project container image.