### PR TITLE
Internal registries

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,27 @@ work well enough for small audiences.
 - [Code Ready Containers 1.13+](https://access.redhat.com/documentation/en-us/red_hat_codeready_containers/1.13/html/getting_started_guide/index)
 - [Minishift 1.34+](https://www.okd.io/minishift/)
 
+## Facilitator Usage
+
+Facilitators of this workshop can automatically provision the requisite components using the supplied playbooks. You
+must have `cluster-admin` or an administrative role that allows creation and modification of `CustomResourceDefinitions`
+and `InstallPlans` at the cluster scope in order to install the operator components used herein.
+
+### Setup the facilitator's local host
+
+The following commands will:
+- Install CLI pre-requisite tools (`oc`, `kubectl`, `argocd`)
+- Install the ArgoCD Operator
+- Instantiate/Deploy the `sample-app`, `sample-app-ci`, and `sample-infra` operands
+
+```
+$ cd /path/to/gitops-workshop/ansible
+$ ansible-playbook -i inventory playbook.yaml \
+  -e kubeconfig=/path/to/kubeconfig \
+  -e scope=cluster||namespace \
+  -e internal_registry=$REGISTRY_NAME \ # Omit this unless using a registry such as Artifactory or Nexus to limit image access
+  -e state=present||absent
+```
 
 ## Agenda
 

--- a/ansible/files/workshop-argo-cluster-cr.yaml
+++ b/ansible/files/workshop-argo-cluster-cr.yaml
@@ -5,13 +5,9 @@ metadata:
   name: workshop-argocd
 spec:
   grafana:
-    enabled: true
-    route:
-      enabled: true
+    enabled: false
   prometheus:
-    enabled: true
-    route:
-      enabled: true
+    enabled: false 
   server:
     route:
       enabled: true

--- a/ansible/participants-setup.yaml
+++ b/ansible/participants-setup.yaml
@@ -35,18 +35,21 @@
       copy:
         src: "{{ playbook_dir }}/../sample-app-ci/"
         dest: "{{ playbook_dir }}/../{{ participant }}-sample-app-ci"
+        mode: preserve
       when: state == 'present'
 
     - name: Remove {{ participant }}-sample-app-ci
       file:
         state: "{{ state }}"
         path: "{{ playbook_dir }}/../{{ participant }}-sample-app-ci"
+        mode: preserve
       when: state != 'present'
 
     - name: "{{ 'Create' if state == 'present' else 'Remove' }} {{ participant }} dirs"
       file:
         state: "{{ 'directory' if state == 'present' else 'absent' }}"
         path: "{{ playbook_dir }}/../{{ participant }}-{{ item }}"
+        mode: preserve
       loop:
         - sample-app-config
         - customresources
@@ -55,6 +58,7 @@
       template:
         src: "{{ playbook_dir }}/templates/sample-app-config/{{ item }}.yaml.j2"
         dest: "{{ playbook_dir }}/../{{ participant }}-sample-app-config/{{ item }}.yaml"
+        mode: preserve
       loop:
         - sample-app-deployment
         - sample-app-namespace
@@ -65,6 +69,7 @@
       template:
         src: "{{ playbook_dir }}/templates/files/{{ item }}.yaml.j2"
         dest: "{{ playbook_dir }}/../{{ participant }}-customresources/{{ item }}.yaml"
+        mode: preserve
       loop:
         - workshop-sample-app-ci-cr
         - workshop-sample-app-cr

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -38,7 +38,7 @@
 
       - name: Populate workshop-argo-cluster-cr.yaml
         template:
-          src: "{{ playbook_dir }}/templates/files/workshop-argo-cluster-cr.yaml"
+          src: "{{ playbook_dir }}/templates/files/workshop-argo-cluster-cr.yaml.j2"
           dest: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
           force: true
     when: internal_registry is defined and internal_registry != "" 
@@ -56,4 +56,11 @@
       - workshop-sample-infra-cr.yaml
       - workshop-sample-app-ci-cr.yaml
     when: state == 'present'
+
+  - name: Cleanup
+    block:
+      - name: temp/argo-cd is absent 
+        file:
+          path: "{{ playbook_dir }}/temp/argo-cd"
+          state: "absent"
 ...

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -41,6 +41,10 @@
           src: "{{ playbook_dir }}/templates/files/workshop-argo-cluster-cr.yaml.j2"
           dest: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
           force: true
+      - name: temp/argo-cd is absent 
+        file:
+          path: "{{ playbook_dir }}/temp/argo-cd"
+          state: "absent"
     when: internal_registry is defined and internal_registry != "" 
 
   - name: Deploy workshop applications
@@ -56,11 +60,4 @@
       - workshop-sample-infra-cr.yaml
       - workshop-sample-app-ci-cr.yaml
     when: state == 'present'
-
-  - name: Cleanup
-    block:
-      - name: temp/argo-cd is absent 
-        file:
-          path: "{{ playbook_dir }}/temp/argo-cd"
-          state: "absent"
 ...

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -8,6 +8,41 @@
   - import_role:
       name: darthlukan.argocd_install.install_argocd
 
+  - name: Apply {{ internal_registry }} to manifests
+    block:
+      - name: Get latest ArgoCD release
+        github_release:
+          user: argoproj
+          repo: argo-cd
+          action: latest_release
+        register: argocd_release
+
+      - name: Get ArgoCD sources
+        git:
+          repo: https://github.com/argoproj/argo-cd.git
+          dest: "{{ playbook_dir }}/temp/argo-cd"
+          version: "{{ argocd_release.tag }}"
+
+      - name: Set Redis deployment manifest fact
+        set_fact:
+          redis_deployment_json: "{{ lookup('file', \"{{ playbook_dir }}/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml\") | from_yaml }}"
+
+      - name: Set redis image fact
+        set_fact:
+          redis_image: "{{ redis_deployment_json.spec.template.spec.containers[0].image }}"
+
+      - name: Set redis image version and image name facts
+        set_fact:
+          redis_image_version: "{{ redis_image.split(':')[-1] }}"
+          redis_image_name: "{{ redis_image.split(':')[0] }}"
+
+      - name: Populate workshop-argo-cluster-cr.yaml
+        template:
+          src: "{{ playbook_dir }}/templates/files/workshop-argo-cluster-cr.yaml"
+          dest: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
+          force: true
+    when: internal_registry is defined and internal_registry != "" 
+
   - name: Deploy workshop applications
     k8s:
       namespace: argocd

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -25,7 +25,7 @@
 
       - name: Set Redis deployment manifest fact
         set_fact:
-          redis_deployment_json: "{{ lookup('file', \"{{ playbook_dir }}/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml\") | from_yaml }}"
+          redis_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml') | from_yaml }}"
 
       - name: Set redis image fact
         set_fact:
@@ -40,12 +40,13 @@
         template:
           src: "{{ playbook_dir }}/templates/files/workshop-argo-cluster-cr.yaml.j2"
           dest: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
+          mode: preserve
           force: true
-      - name: temp/argo-cd is absent 
+      - name: temp/argo-cd is absent
         file:
           path: "{{ playbook_dir }}/temp/argo-cd"
           state: "absent"
-    when: internal_registry is defined and internal_registry != "" 
+    when: internal_registry is defined and internal_registry|length > 0
 
   - name: Deploy workshop applications
     k8s:

--- a/ansible/templates/files/workshop-argo-cluster-cr.yaml.j2
+++ b/ansible/templates/files/workshop-argo-cluster-cr.yaml.j2
@@ -1,0 +1,21 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: workshop-argocd
+spec:
+  grafana:
+    enabled: false 
+  prometheus:
+    enabled: false 
+  redis:
+    image: {{ internal_registry }}/{{ redis_image_name }}
+    version: {{ redis_image_version }} 
+  server:
+    route:
+      enabled: true
+  rbac:
+    defaultPolicy: 'role:readonly'
+    policy: |
+      g, system:cluster-admins, role:admin
+...


### PR DESCRIPTION
This PR includes changes necessary for facilitators to provision the workshop environment on a cluster where an internal registry is configured. By default, ArgoCD and its provided Operator make use of images from a combination of external registries, such as quay.io and hub.docker.com/docker.io, for administrators whose clusters are configured to block these registries and instead use a proxy or mirror registry for those images, it is necessary to be able to specify the  `internal_registry`.

The documentation has also been updated to reflect the options available to facilitators executing the `ansible/playbook.yaml` that configures the workshop environment and the acceptable values to those extra vars.