### PR TITLE
Internal registries expanded

### DIFF
--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -23,18 +23,35 @@
           dest: "{{ playbook_dir }}/temp/argo-cd"
           version: "{{ argocd_release.tag }}"
 
-      - name: Set Redis deployment manifest fact
+      - name: Set deployment manifest facts
         set_fact:
           redis_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml') | from_yaml }}"
+          dex_deployment_json: ""
+          repo_deployment_json: ""
+          app_controller_deployment_json: ""
+          server_deployment_json: ""
 
-      - name: Set redis image fact
+      - name: Set image facts
         set_fact:
           redis_image: "{{ redis_deployment_json.spec.template.spec.containers[0].image }}"
+          dex_image: ""
+          repo_image: ""
+          app_controller_image: ""
+          server_image: ""
 
-      - name: Set redis image version and image name facts
+
+      - name: Set image version and image name facts
         set_fact:
           redis_image_version: "{{ redis_image.split(':')[-1] }}"
           redis_image_name: "{{ redis_image.split(':')[0] }}"
+          dex_image_version: ""
+          dex_image_name: ""
+          repo_image_version: ""
+          repo_image_name: ""
+          app_controller_image_version: ""
+          app_controller_image_name: ""
+          server_image_version: ""
+          server_image_name: ""
 
       - name: Populate workshop-argo-cluster-cr.yaml
         template:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -53,7 +53,6 @@
 
       - name: Backup workshop-argo-cluster-cr
         copy:
-          state: present
           mode: preserve
           src: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
           dest: "{{ playbook_dir }}/original/workshop-argo-cluster-cr.yaml"

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -44,17 +44,32 @@
           server_image_version: "{{ server_image.split(':')[-1] }}"
           server_image_name: "{{ server_image.split(':')[0] }}"
 
+      - name: Backup dir for original workshop-argo-cluster-cr manifest exists
+        file:
+          state: directory
+          recurse: true
+          path: "{{ playbook_dir }}/original"
+          mode: "ugo+rw"
+
+      - name: Backup workshop-argo-cluster-cr
+        copy:
+          state: present
+          mode: preserve
+          src: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
+          dest: "{{ playbook_dir }}/original/workshop-argo-cluster-cr.yaml"
+
       - name: Populate workshop-argo-cluster-cr.yaml
         template:
           src: "{{ playbook_dir }}/templates/files/workshop-argo-cluster-cr.yaml.j2"
           dest: "{{ playbook_dir }}/files/workshop-argo-cluster-cr.yaml"
           mode: preserve
           force: true
+
       - name: temp/argo-cd is absent
         file:
           path: "{{ playbook_dir }}/temp/argo-cd"
           state: "absent"
-    when: internal_registry is defined and internal_registry|length > 0
+    when: internal_registry is defined and internal_registry|length > 0 and state == 'present'
 
   - name: Deploy workshop applications
     k8s:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -35,7 +35,6 @@
           dex_image: "{{ dex_deployment_json.spec.template.spec.containers[0].image }}"
           server_image: "{{ server_deployment_json.spec.template.spec.containers[0].image }}"
 
-
       - name: Set image version and image name facts
         set_fact:
           redis_image_version: "{{ redis_image.split(':')[-1] }}"

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -27,16 +27,12 @@
         set_fact:
           redis_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml') | from_yaml }}"
           dex_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/dex/argocd-dex-server-deployment.yaml') | from_yaml }}"
-          repo_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/repo-server/argocd-repo-server-deployment.yaml') | from_yaml }}"
-          app_controller_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/application-controller/argocd-application-controller-deployment.yaml') | from_yaml }}"
           server_deployment_json: "lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/server/argocd-server-deployment.yaml') | from_yaml }}"
 
       - name: Set image facts
         set_fact:
           redis_image: "{{ redis_deployment_json.spec.template.spec.containers[0].image }}"
           dex_image: "{{ dex_deployment_json.spec.template.spec.containers[0].image }}"
-          repo_image: "{{ repo_deployment_json.spec.template.spec.containers[0].image }}"
-          app_controller_image: "{{ app_controller_deployment_json.spec.template.spec.containers[0].image }}"
           server_image: "{{ server_deployment_json.spec.template.spec.containers[0].image }}"
 
 
@@ -46,10 +42,6 @@
           redis_image_name: "{{ redis_image.split(':')[0] }}"
           dex_image_version: "{{ dex_image.split(':')[-1] }}"
           dex_image_name: "{{ dex_image.split(':')[0] }}"
-          repo_image_version: "{{ repo_image.split(':')[-1] }}"
-          repo_image_name: "{{ repo_image.split(':')[0] }}"
-          app_controller_image_version: "{{ app_controller_image.split(':')[-1] }}"
-          app_controller_image_name: "{{ app_controller_image.split(':')[0] }}"
           server_image_version: "{{ server_image.split(':')[-1] }}"
           server_image_name: "{{ server_image.split(':')[0] }}"
 

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -26,32 +26,32 @@
       - name: Set deployment manifest facts
         set_fact:
           redis_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml') | from_yaml }}"
-          dex_deployment_json: ""
-          repo_deployment_json: ""
-          app_controller_deployment_json: ""
-          server_deployment_json: ""
+          dex_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/dex/argocd-dex-server-deployment.yaml') | from_yaml }}"
+          repo_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/repo-server/argocd-repo-server-deployment.yaml') | from_yaml }}"
+          app_controller_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/application-controller/argocd-application-controller-deployment.yaml') | from_yaml }}"
+          server_deployment_json: "lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/server/argocd-server-deployment.yaml') | from_yaml }}"
 
       - name: Set image facts
         set_fact:
           redis_image: "{{ redis_deployment_json.spec.template.spec.containers[0].image }}"
-          dex_image: ""
-          repo_image: ""
-          app_controller_image: ""
-          server_image: ""
+          dex_image: "{{ dex_deployment_json.spec.template.spec.containers[0].image }}"
+          repo_image: "{{ repo_deployment_json.spec.template.spec.containers[0].image }}"
+          app_controller_image: "{{ app_controller_deployment_json.spec.template.spec.containers[0].image }}"
+          server_image: "{{ server_deployment_json.spec.template.spec.containers[0].image }}"
 
 
       - name: Set image version and image name facts
         set_fact:
           redis_image_version: "{{ redis_image.split(':')[-1] }}"
           redis_image_name: "{{ redis_image.split(':')[0] }}"
-          dex_image_version: ""
-          dex_image_name: ""
-          repo_image_version: ""
-          repo_image_name: ""
-          app_controller_image_version: ""
-          app_controller_image_name: ""
-          server_image_version: ""
-          server_image_name: ""
+          dex_image_version: "{{ dex_image.split(':')[-1] }}"
+          dex_image_name: "{{ dex_image.split(':')[0] }}"
+          repo_image_version: "{{ repo_image.split(':')[-1] }}"
+          repo_image_name: "{{ repo_image.split(':')[0] }}"
+          app_controller_image_version: "{{ app_controller_image.split(':')[-1] }}"
+          app_controller_image_name: "{{ app_controller_image.split(':')[0] }}"
+          server_image_version: "{{ server_image.split(':')[-1] }}"
+          server_image_name: "{{ server_image.split(':')[0] }}"
 
       - name: Populate workshop-argo-cluster-cr.yaml
         template:

--- a/ansible/playbook.yaml
+++ b/ansible/playbook.yaml
@@ -27,7 +27,7 @@
         set_fact:
           redis_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/redis/argocd-redis-deployment.yaml') | from_yaml }}"
           dex_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/dex/argocd-dex-server-deployment.yaml') | from_yaml }}"
-          server_deployment_json: "lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/server/argocd-server-deployment.yaml') | from_yaml }}"
+          server_deployment_json: "{{ lookup('file', playbook_dir + '/temp/argo-cd/manifests/base/server/argocd-server-deployment.yaml') | from_yaml }}"
 
       - name: Set image facts
         set_fact:

--- a/ansible/templates/files/workshop-argo-cluster-cr.yaml.j2
+++ b/ansible/templates/files/workshop-argo-cluster-cr.yaml.j2
@@ -4,10 +4,17 @@ kind: ArgoCD
 metadata:
   name: workshop-argocd
 spec:
+  # Image to use for all ArgoCD server components: server, application-controller, repo-server
+  # by default this is 'argoproj/argocd:latest'
+  image: {{ internal_registry }}/{{ server_image_name }}:{{ server_image_version }}
+
   grafana:
     enabled: false 
   prometheus:
     enabled: false 
+  dex:
+    image: {{ internal_registry }}/{{ dex_image_name }}
+    version: {{ dex_image_version }}
   redis:
     image: {{ internal_registry }}/{{ redis_image_name }}
     version: {{ redis_image_version }} 


### PR DESCRIPTION
This PR expands the `internal_registry` block to include other necessary components using the same method as with `redis`. Tested in CRC for both namespace and cluster scoped installation.